### PR TITLE
margin for store icons

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -254,6 +254,7 @@ a {
 }
 .store-icon {
   width: 160px;
+  margin-top: 30px;
 }
 @media all and (max-width: 940px) {
   .para {

--- a/styles/index.less
+++ b/styles/index.less
@@ -231,6 +231,7 @@ a {
 
 .store-icon {
   width: 160px;
+  margin-top: 30px;
 }
 
 // desktop is default


### PR DESCRIPTION
this style got overriden by accident in #6 

![screen shot](https://cloud.githubusercontent.com/assets/341374/8350291/f6f42e0c-1ad8-11e5-8b86-8ebd5903af9b.png)
